### PR TITLE
TRITON-2315 firewall-logger-agent needs to be part of the release repos

### DIFF
--- a/tools/jr-manifest.json
+++ b/tools/jr-manifest.json
@@ -85,6 +85,7 @@
         {
             "name": "firewall-logger-agent",
             "labels": {
+                "release": true,
                 "tritonservice": "firewall-logger-agent",
                 "mg": "firewall-logger-agent",
                 "agent": true


### PR DESCRIPTION
I hope this is all, but we might need to update TritonDataCenter/sdc-agents-installer too.