### PR TITLE
Fixing broken links in documentation

### DIFF
--- a/docs/developer-guide/iso-installer.md
+++ b/docs/developer-guide/iso-installer.md
@@ -16,7 +16,7 @@ boot once off of DVD-ROM, and on subsequent boots, boot off of a bootable
 `zones` ZFS pool.
 
 The ISO installer can be used in a virtual machine environment, in lieu of
-[CoaL](./docs/developer-guide/coal-setup.md), as well.  Be sure to download
+[CoaL](coal-setup.md), as well.  Be sure to download
 the [ISO
 image](https://us-east.manta.joyent.com/Joyent_Dev/public/SmartDataCenter/iso-latest.iso)
 and follow the main README.
@@ -31,13 +31,13 @@ but is otherwise the same.
 - 60 GB available storage
 
 See the [main README's Physical Server
-section](https://github.com/TritonDataCenter/triton/tree/TRITON-2202#installing-triton-on-a-physical-server)
+section](/README.md#installing-triton-on-a-physical-server)
 for more details
 
 ## Disk/Pool Requirements
 
 See [Booting the Head Node from a ZFS
-Pool](https://github.com/TritonDataCenter/triton/blob/TRITON-2202/docs/developer-guide/zpool.md)
+Pool](zpool.md)
 for details about how to properly set up a ZFS pool that is bootable.
 
 ## Boot-device Requirements

--- a/docs/developer-guide/repos.md
+++ b/docs/developer-guide/repos.md
@@ -120,7 +120,7 @@ to manta:
 
 Documentation repos:
 
-* [sdc](https://github.com/TritonDataCenter/sdc): starting point for SmartDataCenter
+* [triton](https://github.com/TritonDataCenter/triton): starting point for Triton DataCenter (formerly SmartDataCenter)
 * [eng](https://github.com/TritonDataCenter/eng): Joyent Engineering Guide
 * [restdown-brand-remora](https://github.com/TritonDataCenter/restdown-brand-remora): &quot;remora&quot; restdown brand/style for coherent API documentation
 * [oid-docs](https://github.com/TritonDataCenter/oid-docs): Document the Joyent OID tree (1.3.6.1.4.1.38678)
@@ -135,7 +135,7 @@ The other repos are used by one of the other repos above:
 * [node-png-joyent](https://github.com/TritonDataCenter/node-png-joyent): An ancient branch of node-png
 * [node-amqp-joyent](https://github.com/TritonDataCenter/node-amqp-joyent): An ancient branch of node-amqp
 * [node-imgmanifest](https://github.com/TritonDataCenter/node-imgmanifest): Node.js library for working with SmartOS image manifests
-* [sdc-fast-stream](https://github.com/TritonDataCenter/sdc-fast-stream): Stream event messages via node-fast.
+* [node-fast-stream](https://github.com/TritonDataCenter/node-fast-messages): Stream event messages via node-fast.
 * [sdc-fwrule](https://github.com/TritonDataCenter/sdc-fwrule): SmartDataCenter firewall rule parser and object.
 * [aperture-config](https://github.com/TritonDataCenter/aperture-config): Common aperture config for SDC/Manta
 * [node-workflow-moray-backend](https://github.com/TritonDataCenter/node-workflow-moray-backend): A backend for node-workflow built over Moray

--- a/docs/developer-guide/zpool.md
+++ b/docs/developer-guide/zpool.md
@@ -86,7 +86,7 @@ contents, which cannot fit into an iPXE boot-archive/initrd.
 ## Converting from a USB-key (or from one bootable pool to another)
 
 The
-[piadm](https://github.com/TritonDataCenter/smartos-live/blob/master/man/usr/share/man/man1m/piadm.1m.md)(1M)
+[piadm](https://github.com/TritonDataCenter/smartos-live/blob/master/man/usr/share/man/man8/piadm.8.md)(8)
 command can be employed to transfer the current USB-key to a bootable ZFS
 pool.  It can also be used to transfer boot contents from one pool to
 another.  If a pool is not bootable, piadm(1M) will fail.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,7 +7,8 @@ If you have a question, please ask on any of
 ([subscribe](https://www.listbox.com/subscribe/?list_id=247449),
 [archives](http://www.listbox.com/member/archive/247449/=now)),
 **#smartos** on the [Libera.chat IRC network](https://libera.chat),
-or in a [joyent/sdc issue](https://github.com/TritonDataCenter/sdc/issues).
+or in a [TritonDataCenter/triton
+issue](https://github.com/TritonDataCenter/triton/issues).
 
 
 ## Q: I already have SmartOS on my system; how do I upgrade to SDC?

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -37,7 +37,7 @@ See [compute node](#compute-node).
 
 "Cloud on a Laptop" is a VMware virtual appliance providing a full SDC headnode
 for development and testing. See [the
-README](https://github.com/TritonDataCenter/sdc#cloud-on-a-laptop-coal) for getting start
+README](/README.md#cloud-on-a-laptop-coal) for getting started
 with SDC using a recent CoaL build.
 
 ### Compute Node

--- a/docs/operator-guide/configuration.md
+++ b/docs/operator-guide/configuration.md
@@ -113,6 +113,6 @@ provides links to the relevant documentation for each.
 | Service |
 | ------- |
 | [cloudapi](https://github.com/TritonDataCenter/sdc-cloudapi/blob/master/docs/admin.md#sapi-configuration) |
-| [cnapi](https://github.com/TritonDataCenter/sdc-cnapi/blob/master/docs/index.md#sapi-configuration) |
+| [cnapi](https://github.com/TritonDataCenter/sdc-cnapi/tree/master/docs#sapi-configuration) |
 | [papi](https://github.com/TritonDataCenter/sdc-papi/blob/master/docs/index.md#sapi-configuration) |
 | [docker](https://github.com/TritonDataCenter/sdc-docker/tree/master/docs/guide#service-configuration) |


### PR DESCRIPTION
While reading through the documentation, I noticed the link from /[docs](https://github.com/TritonDataCenter/triton/tree/master/docs)/[developer-guide](https://github.com/TritonDataCenter/triton/tree/master/docs/developer-guide)/iso-installer.md labeled "Booting the Head Node from a ZFS Pool" was broken. I cloned the repo, scrubbed all links starting with http, and fixed as many as I could.

developer-guide/build-zone-setup.md has a link to https://updates.tritondatacenter.com/images/bd83a9b3-65cd-4160-be2e-f7c4c56e0606?channel=experimental. I couldn't find a correct replacement.