### PR TITLE
TRITON-2456 Want loadbalancer for Triton tenants

### DIFF
--- a/tools/jr-manifest.json
+++ b/tools/jr-manifest.json
@@ -972,6 +972,15 @@
             "name": "triton-mockcloud-common"
         },
         {
+            "name": "triton-moirai",
+            "labels": {
+                "release": true,
+                "image": "cloud-load-balancer",
+                "mg": "cloud-load-balancer",
+                "vm": true
+            }
+        },
+        {
             "name": "triton-origin-image"
         },
         {


### PR DESCRIPTION
This adds the TritonDataCenter/triton-moirai repo to the list of repos in Triton, even though it's not shipped as part of base Triton.